### PR TITLE
Add inventory-only bounties to the bounty catalog

### DIFF
--- a/src/app/countdown/directives/countdown.directive.ts
+++ b/src/app/countdown/directives/countdown.directive.ts
@@ -24,6 +24,7 @@ export class CountdownDirective extends Destroyable {
     this.dateFeed$.pipe(
       switchMap((dateString) => {
         let seconds = this.getSecondsUntilDate(dateString);
+        this.newSecondValue.emit(seconds);
         return this.secondService.seconds.pipe(
           take(seconds),
           takeUntil(this.destroy$),

--- a/src/app/todo-list/components/grid-cell-renderers/vendor-renderer.component.ts
+++ b/src/app/todo-list/components/grid-cell-renderers/vendor-renderer.component.ts
@@ -8,7 +8,12 @@ import { Bounty, CostReward } from '@app/todo-list/interfaces/vendor.interface';
   template: `
   <div class="multi-line-cell">
     <div>{{vendorName}}</div>
-    <div *ngFor="let cost of costs | costReward" class="type-caption">{{cost}}</div>
+    <div class="type-caption">
+      <ng-container *ngIf="bounty.inVendorStock; else inventoryItem">
+        <div *ngFor="let cost of costs | costReward" >{{cost}}</div>
+      </ng-container>
+      <ng-template #inventoryItem><div>&#8212;</div></ng-template>
+    </div>
   </div>
   `,
 })
@@ -16,6 +21,7 @@ export class VendorRenderer implements ICellRendererAngularComp {
   public params: any;
   public vendorName: string;
   public costs: CostReward[];
+  public bounty: Bounty;
 
   /**
    * should pass in a whole bounty/milestone object
@@ -35,5 +41,6 @@ export class VendorRenderer implements ICellRendererAngularComp {
     this.vendorName = value.vendorName;
     // cost should always be array length 1
     this.costs = value.costs;
+    this.bounty = value;
   }
 }

--- a/src/app/todo-list/interfaces/player.interface.ts
+++ b/src/app/todo-list/interfaces/player.interface.ts
@@ -5,6 +5,7 @@
 import { ClassAllowed } from '@app/service/model';
 
 import { DisplayProperties } from './api.interface';
+import { InventoryItem } from './vendor.interface';
 
 
 /**
@@ -46,4 +47,8 @@ export interface ApiInventoryItem {
   itemHash: number; // 568515759
   expirationDate: string; // "2020-06-24T01:55:35Z"
   itemInstanceId: string; // "6917529194608561468"
+}
+
+export interface InventoryMap {
+  [key: string]: InventoryItem; // where the key is the itemHash of the inventory item
 }

--- a/src/app/todo-list/interfaces/vendor.interface.ts
+++ b/src/app/todo-list/interfaces/vendor.interface.ts
@@ -1,5 +1,6 @@
 import { ItemType } from '@app/service/model';
 import { DisplayProperties } from './api.interface';
+import { ApiInventoryItem } from './player.interface';
 
 /**
  * Represents the `vendors` endpoint with the `vendorSales` component
@@ -23,7 +24,7 @@ export interface VendorSales {
   [key: string]: SaleItem; // key is an arbitrary number
 }
 
-export interface SaleItem {
+export interface SaleItem extends ApiInventoryItem {
   augments: number;
   costs: CostReward[];
   failureIndexes: any[];
@@ -80,6 +81,7 @@ export interface Privacy {
 export interface Bounty extends InventoryItem {
   costs: CostReward[]; // assuming that it's the same cost for each character
   vendorName: string;
+  inVendorStock: boolean // if it's not in vendor stock, then it's only in inventories
   chars: { [key: string]: BountyCharInfo; }
 }
 

--- a/src/app/todo-list/services/context-service.ts
+++ b/src/app/todo-list/services/context-service.ts
@@ -7,7 +7,7 @@ import { filter, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { Destroyable } from '../../util/destroyable';
 import { API_ROOT } from '../constants/constants';
-import { Character } from '../interfaces/player.interface';
+import { Character, InventoryMap } from '../interfaces/player.interface';
 import { DictionaryService } from './dictionary.service';
 import { HttpService } from './http.service';
 
@@ -20,6 +20,10 @@ export class ContextService extends Destroyable {
 
   public user: BehaviorSubject<SelectedUser> = new BehaviorSubject(null);
   public characters: BehaviorSubject<Character[]> = new BehaviorSubject(null);
+  /**
+   * the keys are character Ids
+   */
+  public inventoryMaps: { [key: string]: InventoryMap }
 
   public get currentUser(): SelectedUser { return this.user.getValue(); }
   public get currentCharacters(): Character[] { return this.characters.getValue(); }


### PR DESCRIPTION
When a vendor's stock refreshes the bounties that you have from them in your inventory are still there, but they are no longer associated with the vendor, which had some interesting problems.

More importantly, the bounties in your inventory that have been "orphaned" are not tracked like the normal ones from the vendors.